### PR TITLE
Fix for imporperly encoded URL query parameters

### DIFF
--- a/src/main/java/com/versionone/apiclient/services/BuildResult.java
+++ b/src/main/java/com/versionone/apiclient/services/BuildResult.java
@@ -1,21 +1,49 @@
 package com.versionone.apiclient.services;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
+
+import static java.lang.String.format;
 
 public class BuildResult {
     public final List<String> querystringParts = new ArrayList<String>();
     public final List<String> pathParts = new ArrayList<String>();
+    private final static Log logger = LogFactory.getLog(BuildResult.class);
 
     public String toUrl() {
         String path = TextBuilder.join(pathParts, "/");
+
+        //shim to ensure query string parts are properly encoded
+        encodeQuery();
+
         String querystring = TextBuilder.join(querystringParts, "&");
-        String result = path.concat(querystring != null ? "?" + querystring : "");
+        return path.concat(querystring != null ? "?" + querystring : "");
+    }
 
-        result = result.replace(" ","%20");
-        result = result.replace("[", "%5B");
-        result = result.replace("]", "%5D");
+    private void encodeQuery(){
 
-        return result;
+        //URL Encode all Query String parts
+        int index = 0;
+        for(String querystring: querystringParts){
+            try {
+                final int indexOfEquals = querystring.indexOf("=");
+                final String queryParameter = querystring.substring(0, indexOfEquals);
+                String queryValue = querystring.substring(indexOfEquals+1, querystring.length());
+
+                //decode first in case the rest of the client did encode only part of the value (we don't want to encode values twice!)
+                queryValue = URLDecoder.decode(queryValue, "UTF-8");
+                //replace the query string with a properly encoded string making sure not to encode the HTTP parameter name
+                querystringParts.set(index, queryParameter + "=" + URLEncoder.encode(queryValue, "UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                logger.error(format("Failed to encode query part while building query string:  %s",querystringParts.get(index)), e);
+            }
+            index++;
+        }
     }
 }


### PR DESCRIPTION
Sorry for the noise with the other PRs.  My local Git client went nuts....

This is a fix for an issue I reported to VersionOne support online (see link below) where certain queries fail Java's URI parser validation as they are not properly encoded. This fix decodes the URL querystring parts constructed by the SDK's getToken calls as some things are properly encoded (e.g. date time strings). This allows me to get the actual un-encoded parts without accidentally re-encoding them a second time.

Not being familiar with the SDK in its entirety, this shim decodes query parameter values and then re-encodes them in the query string parts attribute just before the V1Connector makes a call to the VersionOne server. Someone more famliar with SDK might find a more targeted solution that doesn't break the rest of the SDK functionality.

https://support.versionone.com/requests/19367

Stack trace (note I replacedthe base url with to spare the innocent):

Causing: java.lang.IllegalArgumentException: Illegal character in query at index 225: http:///VersionOne/rest-1.v1/Data/Story?sel=Story.Name,Story.Scope.Name,Story.Number,Story.ChangeDate,Story.Owners.Name,Story.Status.Name,Story.Team.Name,Story.Priority.Name&where=(Story.ChangeDate>='2014-07-23T19%3A52%3A41.000-04%3A00';Story.ChangeDate<='2015-07-23T19%3A52%3A41.000-04%3A00')&page=100,0 
! at java.net.URI.create(URI.java:852) ~[na:1.8.0_25] 
! at org.apache.http.client.methods.HttpGet.(HttpGet.java:69) ~[httpclient-4.4.jar:4.4] 
! at com.versionone.apiclient.V1Connector.setGETMethod(V1Connector.java:400) ~[VersionOne.SDK.Java.APIClient-15.1.0.jar:15.1.0] 
! at com.versionone.apiclient.V1Connector.getData(V1Connector.java:357) ~[VersionOne.SDK.Java.APIClient-15.1.0.jar:15.1.0] 
! at com.versionone.apiclient.Services.retrieve(Services.java:118) ~[VersionOne.SDK.Java.APIClient-15.1.0.jar:15.1.0]