### PR TITLE
Remove duplicate header entries

### DIFF
--- a/src/main/java/com/versionone/apiclient/V1Connector.java
+++ b/src/main/java/com/versionone/apiclient/V1Connector.java
@@ -444,7 +444,8 @@ public class V1Connector {
 		String localeName = Locale.getDefault().toString();
 		localeName = localeName.replace("_", "-");
 		boolean uniqueValue = true;
-
+		Header header = new BasicHeader(HttpHeaders.ACCEPT_LANGUAGE, localeName);
+		
 		for ( int i = 0; i < headerArray.length && uniqueValue; ++i ) {
 			Header h = headerArray[i];
 			if (h.getValue().equals(header.getValue()) && h.getName().equals(header.getName())) {

--- a/src/main/java/com/versionone/apiclient/V1Connector.java
+++ b/src/main/java/com/versionone/apiclient/V1Connector.java
@@ -443,9 +443,16 @@ public class V1Connector {
 	private void setDefaultHeaderValue() {
 		String localeName = Locale.getDefault().toString();
 		localeName = localeName.replace("_", "-");
-		Header header = new BasicHeader(HttpHeaders.ACCEPT_LANGUAGE, localeName);
-		headerArray = (Header[]) ArrayUtils.removeElement(headerArray, header);
-		headerArray = (Header[]) ArrayUtils.add(headerArray, header);
+		boolean uniqueValue = true;
+
+		for ( int i = 0; i < headerArray.length && uniqueValue; ++i ) {
+			Header h = headerArray[i];
+			if (h.getValue().equals(header.getValue()) && h.getName().equals(header.getName())) {
+				uniqueValue = false;
+			}
+		}
+		if(uniqueValue)
+			headerArray = (Header[]) ArrayUtils.add(headerArray, header);
 	}
 
 	protected Reader sendData(String path, Object data) throws ConnectionException {


### PR DESCRIPTION
I ran into an issue where I was querying the VersionOne API via the Java SDK 100+ times in one run of my application. So Services.retrieve -> V1Connector.getData -> V1Connector.setGetMethod which calls setDefaultHeaderValue. If you look at the previous implementation on master it assumes that ArrayUtils.removeElement will remove the first element that equals header, but digging into this I found that it does an object comparison and not a value comparison thus it will never remove the locale header, because it is a unique object, and will always append it to headerArray. In my case this was filling the array to the point where it couldn't be processed by the API (ie the request was getting too large). Below you can see my fix for this.