### PR TITLE
The fields on the V1Connector shouldn't be static

### DIFF
--- a/src/main/java/com/versionone/apiclient/V1Connector.java
+++ b/src/main/java/com/versionone/apiclient/V1Connector.java
@@ -45,14 +45,14 @@ import com.versionone.utils.V1Util;
 
 public class V1Connector {
 
-	private static final String contentType = "text/xml";
-	private static CredentialsProvider credsProvider = new BasicCredentialsProvider();
-	private static CloseableHttpResponse httpResponse = null;
-	private static HttpClientBuilder httpclientBuilder = HttpClientBuilder.create();
-	private static CloseableHttpClient httpclient;
-	private static Header[] headerArray = {};
-	private static HttpPost httpPost;
-	private static boolean isWindowsAuth = false;
+	private final String contentType = "text/xml";
+	private CredentialsProvider credsProvider = new BasicCredentialsProvider();
+	private CloseableHttpResponse httpResponse = null;
+	private HttpClientBuilder httpclientBuilder = HttpClientBuilder.create();
+	private CloseableHttpClient httpclient;
+	private Header[] headerArray = {};
+	private HttpPost httpPost;
+	private boolean isWindowsAuth = false;
 
 	private final Map<String, OutputStream> _pendingStreams = new HashMap<String, OutputStream>();
 	private final Map<String, String> _pendingContentTypes = new HashMap<String, String>();
@@ -210,6 +210,10 @@ public class V1Connector {
 		V1Connector build();
 	}
 
+	public V1Connector() {
+		super();
+	}
+
 	protected V1Connector(String instanceUrl) throws V1Exception, MalformedURLException {
 
 		if (V1Util.isNullOrEmpty(instanceUrl)) {
@@ -225,12 +229,12 @@ public class V1Connector {
 		INSTANCE_URL = urlData;
 	}
 
-	public static ISetUserAgentMakeRequest withInstanceUrl(String instanceUrl) throws V1Exception, MalformedURLException {
+	public ISetUserAgentMakeRequest withInstanceUrl(String instanceUrl) throws V1Exception, MalformedURLException {
 		return new Builder(instanceUrl);
 	}
 
 	// // Fluent BUILDER ///
-	private static class Builder implements ISetUserAgentMakeRequest, IAuthenticationMethods, IsetProxyOrEndPointOrConnector, IsetProxyOrConnector, IsetEndPointOrConnector {
+	private class Builder implements ISetUserAgentMakeRequest, IAuthenticationMethods, IsetProxyOrEndPointOrConnector, IsetProxyOrConnector, IsetEndPointOrConnector {
 
 		private V1Connector v1Connector_instance;
 
@@ -252,8 +256,8 @@ public class V1Connector {
 					+ p.getImplementationVersion();
 
 			Header header = new BasicHeader(HttpHeaders.USER_AGENT, headerString);
-			headerArray = (Header[]) ArrayUtils.add(headerArray, header);
-			isWindowsAuth = false;
+			v1Connector_instance.headerArray = (Header[]) ArrayUtils.add(v1Connector_instance.headerArray, header);
+			v1Connector_instance.isWindowsAuth = false;
 
 			return this;
 		}
@@ -265,10 +269,10 @@ public class V1Connector {
 			if (V1Util.isNullOrEmpty(username) || V1Util.isNullOrEmpty(username))
 				throw new NullPointerException("Username and password values cannot be null or empty.");
 
-			credsProvider.setCredentials(new AuthScope(v1Connector_instance.INSTANCE_URL.getHost(), v1Connector_instance.INSTANCE_URL.getPort()),
+			v1Connector_instance.credsProvider.setCredentials(new AuthScope(v1Connector_instance.INSTANCE_URL.getHost(), v1Connector_instance.INSTANCE_URL.getPort()),
 					new UsernamePasswordCredentials(username, password));
-			httpclientBuilder.setDefaultCredentialsProvider(credsProvider);
-			isWindowsAuth = false;
+			v1Connector_instance.httpclientBuilder.setDefaultCredentialsProvider(v1Connector_instance.credsProvider);
+			v1Connector_instance.isWindowsAuth = false;
 
 			return this;
 		}
@@ -281,8 +285,8 @@ public class V1Connector {
 				throw new NullPointerException("Access token value cannot be null or empty.");
 
 			Header header = new BasicHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-			headerArray = (Header[]) ArrayUtils.add(headerArray, header);
-			isWindowsAuth = false;
+			v1Connector_instance.headerArray = (Header[]) ArrayUtils.add(v1Connector_instance.headerArray, header);
+			v1Connector_instance.isWindowsAuth = false;
 
 			return this;
 		}
@@ -294,9 +298,9 @@ public class V1Connector {
 				throw new NullPointerException("Access token value cannot be null or empty.");
 
 			Header header = new BasicHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-			headerArray = (Header[]) ArrayUtils.add(headerArray, header);
+			v1Connector_instance.headerArray = (Header[]) ArrayUtils.add(v1Connector_instance.headerArray, header);
 
-			isWindowsAuth = false;
+			v1Connector_instance.isWindowsAuth = false;
 
 			return this;
 		}
@@ -304,8 +308,8 @@ public class V1Connector {
 		@Override
 		public IsetProxyOrEndPointOrConnector withWindowsIntegrated() throws V1Exception {
 
-			httpclient = WinHttpClients.createDefault();
-			isWindowsAuth = true;
+			v1Connector_instance.httpclient = WinHttpClients.createDefault();
+			v1Connector_instance.isWindowsAuth = true;
 
 			return this;
 		}
@@ -317,12 +321,12 @@ public class V1Connector {
 				throw new NullPointerException("ProxyProvider value cannot be null or empty.");
 			}
 
-			credsProvider.setCredentials(new AuthScope(proxyProvider.getAddress().getHost(), proxyProvider.getAddress().getPort()),
+			v1Connector_instance.credsProvider.setCredentials(new AuthScope(proxyProvider.getAddress().getHost(), proxyProvider.getAddress().getPort()),
 					new UsernamePasswordCredentials(proxyProvider.getUserName(), proxyProvider.getPassword()));
 
 			HttpHost proxy = new HttpHost(proxyProvider.getAddress().getHost(), proxyProvider.getAddress().getPort());
-			httpclientBuilder.setDefaultCredentialsProvider(credsProvider).setProxy(proxy);
-			isWindowsAuth = false;
+			v1Connector_instance.httpclientBuilder.setDefaultCredentialsProvider(v1Connector_instance.credsProvider).setProxy(proxy);
+			v1Connector_instance.isWindowsAuth = false;
 
 			return this;
 		}

--- a/src/test/java/com/versionone/sdk/integration/tests/APIClientIntegrationTestSuiteIT.java
+++ b/src/test/java/com/versionone/sdk/integration/tests/APIClientIntegrationTestSuiteIT.java
@@ -85,13 +85,15 @@ public class APIClientIntegrationTestSuiteIT {
 		
 		//Create the V1Connector.
 		if (_use_oauth.equals("true")){
-					_connector = V1Connector.withInstanceUrl(_instanceUrl)
+					V1Connector conn = new V1Connector();
+					_connector = conn.withInstanceUrl(_instanceUrl)
 							.withUserAgentHeader("JavaSDKIntegrationTests", "1.0")
 							.withAccessToken(_accessToken)
 							.useOAuthEndpoints()
 							.build();
 		}else{
-				_connector = V1Connector
+			V1Connector conn = new V1Connector();
+				_connector = conn
 						.withInstanceUrl(_instanceUrl)
 						.withUserAgentHeader("JavaSDKIntegrationTests", "1.0")
 						.withAccessToken(_accessToken)

--- a/src/test/java/com/versionone/sdk/integration/tests/Connector.java
+++ b/src/test/java/com/versionone/sdk/integration/tests/Connector.java
@@ -39,7 +39,8 @@ public class Connector {
 	public void ConnectorWithUsernameAndPassword() throws MalformedURLException, V1Exception {
 
 		if (!_use_oauth.equals("true")){
-			V1Connector connector = V1Connector.withInstanceUrl(_instanceUrl)
+			V1Connector conn = new V1Connector();
+			V1Connector connector = conn.withInstanceUrl(_instanceUrl)
 					.withUserAgentHeader("JavaSDKIntegrationTests", "1.0")
 					.withUsernameAndPassword(_username, _password)
 					.build();
@@ -54,7 +55,8 @@ public class Connector {
 	public void ConnectorWithAccessToken() throws Exception {
 		
 		if (!_use_oauth.equals("true")){
-			V1Connector connector = V1Connector.withInstanceUrl(_instanceUrl)
+			V1Connector conn = new V1Connector();
+			V1Connector connector = conn.withInstanceUrl(_instanceUrl)
 					.withUserAgentHeader("JavaSDKIntegrationTests", "1.0")
 					.withAccessToken(_accessToken)
 					.build();

--- a/src/test/java/com/versionone/sdk/integration/tests/QueryAssets.java
+++ b/src/test/java/com/versionone/sdk/integration/tests/QueryAssets.java
@@ -405,7 +405,8 @@ public class QueryAssets {
 		assertNotNull("Test file missing", Thread.currentThread().getContextClassLoader().getResource(file));
 		String mimeType = MimeType.resolve(file);
 
-		IAttachments attachments = new Attachments(V1Connector.withInstanceUrl(_instanceUrl).withUserAgentHeader(".NET_SDK_Integration_Test", "1.0")
+		V1Connector conn = new V1Connector();
+		IAttachments attachments = new Attachments(conn.withInstanceUrl(_instanceUrl).withUserAgentHeader(".NET_SDK_Integration_Test", "1.0")
 				.withAccessToken(_accessToken).useEndpoint("attachment.img/").build());
 
 		IAssetType storyType = _services.getMeta().getAssetType("Story");


### PR DESCRIPTION
When these fields are static, if you create multiple instances of the V1Connector within the same jvm, it causes the connection to fail as soon as a request goes into failed state.
Having them non-static fixes this.