### PR TITLE
Fixes to prevent locking and high CPU

### DIFF
--- a/src/main/java/com/versionone/apiclient/AssetType.java
+++ b/src/main/java/com/versionone/apiclient/AssetType.java
@@ -1,18 +1,16 @@
 package com.versionone.apiclient;
 
-import java.util.Map;
-
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
-
-import org.w3c.dom.Element;
-
 import com.versionone.apiclient.exceptions.MetaException;
 import com.versionone.apiclient.interfaces.IAssetType;
 import com.versionone.apiclient.interfaces.IAttributeDefinition;
 import com.versionone.apiclient.interfaces.IMetaModel;
 import com.versionone.apiclient.interfaces.IOperation;
+import com.versionone.util.XPathFactoryInstanceHolder;
+import org.w3c.dom.Element;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import java.util.Map;
 
 /**
  * Represents information about an asset type
@@ -51,7 +49,7 @@ class AssetType implements IAssetType {
 		_displayname = element.getAttribute("displayname");
 		_token = element.getAttribute("token");
 
-		XPath xpath = XPathFactory.newInstance().newXPath();
+		XPath xpath = XPathFactoryInstanceHolder.get().newXPath();
 		Element baseelement = (Element)xpath.evaluate("Base", element, XPathConstants.NODE);
 		if (baseelement != null)
 			_basetoken = baseelement.getAttribute("nameref");

--- a/src/main/java/com/versionone/apiclient/AttributeDefinition.java
+++ b/src/main/java/com/versionone/apiclient/AttributeDefinition.java
@@ -1,11 +1,5 @@
 package com.versionone.apiclient;
 
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
-
-import org.w3c.dom.Element;
-
 import com.versionone.DB;
 import com.versionone.Duration;
 import com.versionone.Oid;
@@ -18,6 +12,11 @@ import com.versionone.apiclient.interfaces.IAssetType;
 import com.versionone.apiclient.interfaces.IAttributeDefinition;
 import com.versionone.apiclient.interfaces.IMetaModel;
 import com.versionone.apiclient.services.TextBuilder;
+import com.versionone.util.XPathFactoryInstanceHolder;
+import org.w3c.dom.Element;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
 
 /**
  * Represents the definition of an Attribute
@@ -61,7 +60,7 @@ class AttributeDefinition implements IAttributeDefinition {
 		_isrequired = new DB.Bit(element.getAttribute("isrequired")).booleanValue();
 		_ismultivalue = new DB.Bit(element.getAttribute("ismultivalue")).booleanValue();
 
-		XPath xpath = XPathFactory.newInstance().newXPath();
+		XPath xpath = XPathFactoryInstanceHolder.get().newXPath();
 		Element baseelement = (Element)xpath.evaluate("Base", element, XPathConstants.NODE);
 		if (baseelement != null)
 			_basetoken = baseelement.getAttribute("tokenref");

--- a/src/main/java/com/versionone/apiclient/MetaModel.java
+++ b/src/main/java/com/versionone/apiclient/MetaModel.java
@@ -15,14 +15,14 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Concrete class for obtaining metadata from the VersionOne server
  */
 public class MetaModel implements IMetaModel {
-	private Map<String, Object> _map = new HashMap<String, Object>();
+	private Map<String, Object> _map = new ConcurrentHashMap<>();
 	private IAPIConnector _connector;
 	private Version _version;
 	private String _versionString = null;

--- a/src/main/java/com/versionone/apiclient/MetaModel.java
+++ b/src/main/java/com/versionone/apiclient/MetaModel.java
@@ -1,28 +1,22 @@
 package com.versionone.apiclient;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
-
+import com.versionone.apiclient.exceptions.ConnectionException;
+import com.versionone.apiclient.exceptions.MetaException;
+import com.versionone.apiclient.exceptions.V1Exception;
+import com.versionone.apiclient.interfaces.*;
+import com.versionone.apiclient.services.TextBuilder;
+import com.versionone.util.XPathFactoryInstanceHolder;
+import com.versionone.utils.Version;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-import com.versionone.apiclient.exceptions.ConnectionException;
-import com.versionone.apiclient.exceptions.MetaException;
-import com.versionone.apiclient.exceptions.V1Exception;
-import com.versionone.apiclient.interfaces.IAPIConnector;
-import com.versionone.apiclient.interfaces.IAssetType;
-import com.versionone.apiclient.interfaces.IAttributeDefinition;
-import com.versionone.apiclient.interfaces.IMetaModel;
-import com.versionone.apiclient.interfaces.IOperation;
-import com.versionone.apiclient.services.TextBuilder;
-import com.versionone.utils.Version;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Concrete class for obtaining metadata from the VersionOne server
@@ -189,7 +183,7 @@ public class MetaModel implements IMetaModel {
 		AssetType assetType = new AssetType(this, doc.getDocumentElement(), _map);
 		saveAssetType(assetType);
 
-		XPath xpath = XPathFactory.newInstance().newXPath();
+		XPath xpath = XPathFactoryInstanceHolder.get().newXPath();
 		NodeList attribnodes = (NodeList) xpath.evaluate("AttributeDefinition", doc.getDocumentElement(), XPathConstants.NODESET);
 		for (int attrIndex = 0; attrIndex < attribnodes.getLength(); ++attrIndex)
 			saveAttributeDefinition(new AttributeDefinition(this, (Element) attribnodes.item(attrIndex)));
@@ -219,7 +213,7 @@ public class MetaModel implements IMetaModel {
 		try {
 			Document doc = this.createDocument("");
 
-			XPath xpath = XPathFactory.newInstance().newXPath();
+			XPath xpath = XPathFactoryInstanceHolder.get().newXPath();
 			NodeList assetnodes = (NodeList) xpath.evaluate("//AssetType", doc.getDocumentElement(), XPathConstants.NODESET);
 			for (int assetIndex = 0; assetIndex < assetnodes.getLength(); ++assetIndex) {
 				Element element = (Element) assetnodes.item(assetIndex);

--- a/src/main/java/com/versionone/apiclient/Services.java
+++ b/src/main/java/com/versionone/apiclient/Services.java
@@ -1,27 +1,14 @@
 package com.versionone.apiclient;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpression;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
-
+import com.versionone.DB;
+import com.versionone.Oid;
+import com.versionone.apiclient.exceptions.*;
+import com.versionone.apiclient.filters.FilterTerm;
+import com.versionone.apiclient.interfaces.*;
+import com.versionone.apiclient.services.QueryResult;
+import com.versionone.apiclient.services.QueryURLBuilder;
+import com.versionone.util.XPathFactoryInstanceHolder;
+import com.versionone.utils.V1Util;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.NullArgumentException;
 import org.apache.commons.lang.StringUtils;
@@ -31,24 +18,10 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import com.versionone.DB;
-import com.versionone.Oid;
-import com.versionone.apiclient.exceptions.APIException;
-import com.versionone.apiclient.exceptions.ConnectionException;
-import com.versionone.apiclient.exceptions.MetaException;
-import com.versionone.apiclient.exceptions.NotImplementedException;
-import com.versionone.apiclient.exceptions.OidException;
-import com.versionone.apiclient.exceptions.V1Exception;
-import com.versionone.apiclient.filters.FilterTerm;
-import com.versionone.apiclient.interfaces.IAPIConnector;
-import com.versionone.apiclient.interfaces.IAssetType;
-import com.versionone.apiclient.interfaces.IAttributeDefinition;
-import com.versionone.apiclient.interfaces.IMetaModel;
-import com.versionone.apiclient.interfaces.IOperation;
-import com.versionone.apiclient.interfaces.IServices;
-import com.versionone.apiclient.services.QueryResult;
-import com.versionone.apiclient.services.QueryURLBuilder;
-import com.versionone.utils.V1Util;
+import javax.xml.xpath.*;
+import java.io.*;
+import java.net.URLEncoder;
+import java.util.*;
 
 /**
  * Wraps the services available in the VersionOne API
@@ -483,7 +456,7 @@ public class Services implements IServices {
 
 		int total = Integer.parseInt(element.getAttribute("total"));
 
-		XPath xpath = XPathFactory.newInstance().newXPath();
+		XPath xpath = XPathFactoryInstanceHolder.get().newXPath();
 		NodeList nodes;
 		try {
 			removeEmptyTextNodes(element);					

--- a/src/main/java/com/versionone/apiclient/V1Configuration.java
+++ b/src/main/java/com/versionone/apiclient/V1Configuration.java
@@ -1,20 +1,15 @@
 package com.versionone.apiclient;
 
-import java.io.Reader;
-
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpression;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
-
-import org.apache.commons.lang.NullArgumentException;
-import org.w3c.dom.Document;
-
 import com.versionone.apiclient.exceptions.APIException;
 import com.versionone.apiclient.exceptions.ConnectionException;
 import com.versionone.apiclient.interfaces.IAPIConnector;
 import com.versionone.apiclient.interfaces.IV1Configuration;
+import com.versionone.util.XPathFactoryInstanceHolder;
+import org.apache.commons.lang.NullArgumentException;
+import org.w3c.dom.Document;
+
+import javax.xml.xpath.*;
+import java.io.Reader;
 
 /**
  * Class to access to VersionOne server configuration
@@ -130,7 +125,7 @@ public class V1Configuration implements IV1Configuration {
 
     private String getSetting(String keyToFind) throws ConnectionException, APIException {
         try {
-            XPathFactory factory = XPathFactory.newInstance();
+            XPathFactory factory = XPathFactoryInstanceHolder.get();
             XPath xpath = factory.newXPath();
 
             XPathExpression expr = xpath.compile("//Configuration/Setting[@key=\"" + keyToFind + "\"]/@value");

--- a/src/main/java/com/versionone/util/XPathFactoryInstanceHolder.java
+++ b/src/main/java/com/versionone/util/XPathFactoryInstanceHolder.java
@@ -1,0 +1,30 @@
+package com.versionone.util;
+
+import javax.xml.xpath.XPathFactory;
+
+/**
+ * Holding a XmlFactory instance using ThreadLocal.
+ * <p>
+ * This approach to fix issues that VersionOne always call {@link XPathFactory#newInstance()} whenever they use it.
+ * 
+ * @author tuanle
+ *
+ */
+public class XPathFactoryInstanceHolder {
+  private static final ThreadLocal<XPathFactory> xpathFactoryInstanceHolder = new ThreadLocal<XPathFactory>();
+
+  /**
+   * Get or create new instance of XPathFactory.
+   * 
+   * @return
+   */
+  public static XPathFactory get() {
+    XPathFactory factory = xpathFactoryInstanceHolder.get();
+    if (null == factory) {
+      factory = XPathFactory.newInstance();
+      xpathFactoryInstanceHolder.set(factory);
+    }
+    return factory;
+  }
+
+}

--- a/src/test/java/com/versionone/sdk/unit/tests/ResponseConnector.java
+++ b/src/test/java/com/versionone/sdk/unit/tests/ResponseConnector.java
@@ -1,13 +1,11 @@
 package com.versionone.sdk.unit.tests;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.HashMap;
-import java.util.Map;
+import com.versionone.apiclient.exceptions.ConnectionException;
+import com.versionone.apiclient.exceptions.NotImplementedException;
+import com.versionone.apiclient.interfaces.IAPIConnector;
+import com.versionone.util.XPathFactoryInstanceHolder;
+import org.w3c.dom.*;
+import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -15,20 +13,9 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
-
-import org.w3c.dom.Attr;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.Text;
-import org.xml.sax.SAXException;
-
-import com.versionone.apiclient.exceptions.ConnectionException;
-import com.versionone.apiclient.exceptions.NotImplementedException;
-import com.versionone.apiclient.interfaces.IAPIConnector;
+import java.io.*;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ResponseConnector implements IAPIConnector {
 
@@ -58,7 +45,7 @@ public class ResponseConnector implements IAPIConnector {
 
 			String[] parts = keys.split(";");
 
-			XPath xpath = XPathFactory.newInstance().newXPath();
+			XPath xpath = XPathFactoryInstanceHolder.get().newXPath();
 			for(String part : parts)
 			{
 				NodeList nodes = (NodeList)xpath.evaluate("Test[@name='" + part + "']", doc.getDocumentElement(), XPathConstants.NODESET);


### PR DESCRIPTION
Fixes to prevent locking and high CPU:

* cache XPathFactory.newInstance() in ThreadLocal - avoid thread locking
* replace HashMap with ConcurrentHashMap in MetaModel - HashMap.put causes high CPU usage when being used concurrently