### PR TITLE
D-10596 Client should support Guid datatypes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.versionone</groupId>
 	<artifactId>VersionOne.SDK.Java.APIClient</artifactId>
-	<version>15.3.0</version>
+	<version>15.3.1</version>
 	<packaging>jar</packaging>
 
 	<name>VersionOne.SDK.Java.APIClient</name>

--- a/src/main/java/com/versionone/apiclient/AttributeDefinition.java
+++ b/src/main/java/com/versionone/apiclient/AttributeDefinition.java
@@ -1,9 +1,12 @@
 package com.versionone.apiclient;
 
+import java.util.UUID;
+
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
+import org.apache.commons.lang.NullArgumentException;
 import org.w3c.dom.Element;
 
 import com.versionone.DB;
@@ -113,6 +116,10 @@ class AttributeDefinition implements IAttributeDefinition {
 				return new DB.BigInt(value).getValue();
             case Blob:
                 return value;
+            case Guid:
+                if (value == null)
+                    throw new NullArgumentException("value");
+                return UUID.fromString(new DB.Str(value).getValue());    
 			default:
 				throw new MetaException("Unsupported AttributeType ", getAttributeType().toString());
 		}

--- a/src/main/java/com/versionone/apiclient/AttributeDefinition.java
+++ b/src/main/java/com/versionone/apiclient/AttributeDefinition.java
@@ -7,6 +7,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.lang.NullArgumentException;
+import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.Element;
 
 import com.versionone.DB;
@@ -117,7 +118,7 @@ class AttributeDefinition implements IAttributeDefinition {
             case Blob:
                 return value;
             case Guid:
-                if (value == null)
+                if (value == null || StringUtils.isEmpty(value.toString()))
                     throw new NullArgumentException("value");
                 return UUID.fromString(new DB.Str(value).getValue());    
 			default:

--- a/src/main/java/com/versionone/apiclient/interfaces/IAttributeDefinition.java
+++ b/src/main/java/com/versionone/apiclient/interfaces/IAttributeDefinition.java
@@ -29,6 +29,7 @@ public interface IAttributeDefinition {
 		Rank,
 		Blob,
 		LongInt,
+		Guid,
 	}
 
 	/**

--- a/src/test/java/com/versionone/sdk/unit/tests/AttributeDefinitionTests.java
+++ b/src/test/java/com/versionone/sdk/unit/tests/AttributeDefinitionTests.java
@@ -37,6 +37,18 @@ public class AttributeDefinitionTests extends MetaTestBase {
 	}
 	
 	@Test
+	public void GuidAttribute() throws V1Exception {
+		IAttributeDefinition def = getMeta().getAttributeDefinition("Publication.Payload");
+		Assert.assertEquals("Publication", def.getAssetType().getToken());
+		Assert.assertEquals("Payload", def.getName());
+		Assert.assertEquals(IAttributeDefinition.AttributeType.Guid, def.getAttributeType());
+		Assert.assertEquals("AttributeDefinition'Payload'Publication", def.getDisplayName());
+		Assert.assertFalse(def.isMultiValue());
+		Assert.assertFalse(def.isReadOnly());
+		Assert.assertTrue(def.isRequired());
+	}
+	
+	@Test
 	public void TestBooleanCoerce() throws V1Exception
 	{
 		// get a Boolean Attribute

--- a/src/test/java/com/versionone/sdk/unit/tests/AttributeDefinitionTests.java
+++ b/src/test/java/com/versionone/sdk/unit/tests/AttributeDefinitionTests.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import com.versionone.apiclient.exceptions.MetaException;
 import com.versionone.apiclient.exceptions.V1Exception;
 import com.versionone.apiclient.interfaces.IAttributeDefinition;
+import com.versionone.apiclient.interfaces.IAttributeDefinition.AttributeType;
 
 public class AttributeDefinitionTests extends MetaTestBase {
 
@@ -73,6 +74,13 @@ public class AttributeDefinitionTests extends MetaTestBase {
 		result = attributeDef.coerce("True");
 		validateBitTrue(result);
 	}
+	
+	@Test 
+	public void CanParseGuidAttributeDefinitionType() {
+		IAttributeDefinition def = getMeta().getAttributeDefinition("Publication.Payload");
+		Assert.assertEquals(AttributeType.Guid, def.getAttributeType());
+	}
+	
 	
 	private void validateBitTrue(Object testMe) {
 		Assert.assertNotNull(testMe);

--- a/src/test/java/com/versionone/sdk/unit/tests/ServicesTests.java
+++ b/src/test/java/com/versionone/sdk/unit/tests/ServicesTests.java
@@ -184,7 +184,6 @@ public class ServicesTests extends ServicesTesterBase {
 
 		Assert.assertEquals(payloadGuid, payloadFromResult);
 		
-		result.getAssets()[0].setAttributeValue(payloadAttribute, payloadGuid);
 	}
 
 	@Test

--- a/src/test/java/com/versionone/sdk/unit/tests/ServicesTests.java
+++ b/src/test/java/com/versionone/sdk/unit/tests/ServicesTests.java
@@ -2,8 +2,15 @@ package com.versionone.sdk.unit.tests;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.sun.jna.platform.win32.Guid.GUID;
 import com.versionone.apiclient.*;
+import com.versionone.apiclient.exceptions.APIException;
+import com.versionone.apiclient.exceptions.ConnectionException;
+import com.versionone.apiclient.exceptions.OidException;
 import com.versionone.apiclient.exceptions.V1Exception;
+import com.versionone.apiclient.filters.FilterTerm;
+
+import org.apache.commons.lang.NullArgumentException;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,6 +21,7 @@ import com.versionone.apiclient.interfaces.IAttributeDefinition;
 import com.versionone.apiclient.services.QueryResult;
 
 import java.net.MalformedURLException;
+import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
@@ -155,4 +163,48 @@ public class ServicesTests extends ServicesTesterBase {
 		asset.setAttributeValue(nameAttributeDefinition, "Fred");
 		Assert.assertTrue(asset.hasChanged());
 	}
+	
+	@Test
+	public void Asset_with_valid_Guid_Attribute() throws ConnectionException, APIException, OidException {
+		UUID payloadGuid = UUID.fromString("98771fb4-71b8-42ec-be8b-69414daa020e");
+
+		Services subject = new Services(getMeta(), getDataConnector());
+		IAssetType publicationType = getMeta().getAssetType("Publication");
+		IAttributeDefinition payloadAttribute = publicationType.getAttributeDefinition("Payload");
+
+		Query query = new Query(publicationType);
+		query.getSelection().add(payloadAttribute);
+		FilterTerm filter = new FilterTerm(payloadAttribute);
+		filter.equal(payloadGuid);
+		query.setFilter(filter);
+
+		QueryResult result = subject.retrieve(query);
+
+		UUID payloadFromResult = (UUID) result.getAssets()[0].getAttribute(payloadAttribute).getValue();
+
+		Assert.assertEquals(payloadGuid, payloadFromResult);
+	}
+
+	@Test
+	public void Asset_with_null_Guid_Attribute() throws OidException {
+		Services subject = new Services(getMeta(), getDataConnector());
+		Query query = new Query(Oid.fromToken("Publication:12346", getMeta()));
+
+		IAssetType publicationType = getMeta().getAssetType("Publication");
+		IAttributeDefinition payloadAttribute = publicationType
+				.getAttributeDefinition("Payload");
+		query.getSelection().add(payloadAttribute);
+
+		try {
+			subject.retrieve(query);
+		} catch (NullArgumentException ex) {
+			Assert.assertEquals(
+					"value must not be null.",
+					ex.getMessage());
+			return;
+		} catch (Exception ex) {
+			Assert.fail("Expected to raise ApiException, but did not.");
+		}
+	}
+	 
 }

--- a/src/test/java/com/versionone/sdk/unit/tests/ServicesTests.java
+++ b/src/test/java/com/versionone/sdk/unit/tests/ServicesTests.java
@@ -187,7 +187,7 @@ public class ServicesTests extends ServicesTesterBase {
 	}
 
 	@Test
-	public void Asset_with_null_Guid_Attribute() throws OidException {
+	public void Asset_with_null_Guid_Attribute() throws OidException, ConnectionException, APIException {
 		Services subject = new Services(getMeta(), getDataConnector());
 		Query query = new Query(Oid.fromToken("Publication:12346", getMeta()));
 
@@ -203,9 +203,9 @@ public class ServicesTests extends ServicesTesterBase {
 					"value must not be null.",
 					ex.getMessage());
 			return;
-		} catch (Exception ex) {
-			Assert.fail("Expected to raise NullArgumentException, but did not.");
 		}
+
+		Assert.fail("Expected to raise NullArgumentException, but did not.");
 	}
 	 
 }

--- a/src/test/java/com/versionone/sdk/unit/tests/ServicesTests.java
+++ b/src/test/java/com/versionone/sdk/unit/tests/ServicesTests.java
@@ -183,6 +183,8 @@ public class ServicesTests extends ServicesTesterBase {
 		UUID payloadFromResult = (UUID) result.getAssets()[0].getAttribute(payloadAttribute).getValue();
 
 		Assert.assertEquals(payloadGuid, payloadFromResult);
+		
+		result.getAssets()[0].setAttributeValue(payloadAttribute, payloadGuid);
 	}
 
 	@Test
@@ -203,7 +205,7 @@ public class ServicesTests extends ServicesTesterBase {
 					ex.getMessage());
 			return;
 		} catch (Exception ex) {
-			Assert.fail("Expected to raise ApiException, but did not.");
+			Assert.fail("Expected to raise NullArgumentException, but did not.");
 		}
 	}
 	 

--- a/testdata/TestData.xml
+++ b/testdata/TestData.xml
@@ -418,6 +418,32 @@
 			  <Asset href="/VersionOne/rest-1.v1/Data/Member/1001" idref="Member:1001" />
 			</Relation>
 		</Response>
+		<Response path="meta.v1/Publication">
+			<AssetType href="/v1.six/meta.v1/Publication" version="16.3.2.207" name="Publication" token="Publication" displayname="AssetType'Publication" abstract="False">
+				<DefaultOrderBy href="/v1.six/meta.v1/Publication/Name" tokenref="Publication.Name"/>
+				<DefaultDisplayBy href="/v1.six/meta.v1/Publication/Name" tokenref="Publication.Name"/>
+				<Name href="/v1.six/meta.v1/Publication/Name" tokenref="Publication.Name"/>
+				<AttributeDefinition name="ID" token="Publication.ID" displayname="AttributeDefinition'ID'Publication" attributetype="Relation" isreadonly="True" isrequired="False" ismultivalue="False" iscanned="True" iscustom="False">
+					<ReciprocalRelation href="/v1.six/meta.v1/Publication/ID" tokenref="Publication.ID"/>
+					<OrderByAttribute href="/v1.six/meta.v1/Publication/ID" tokenref="Publication.ID"/>
+					<DisplayByAttribute href="/v1.six/meta.v1/Publication/Name" tokenref="Publication.Name"/>
+					<RelatedAsset nameref="Publication" href="/v1.six/meta.v1/Publication"/>
+				</AttributeDefinition>
+				<AttributeDefinition href="/v1.six/meta.v1/Publication/Payload" of="/v1.six/meta.v1/Publication" version="16.3.2.207" name="Payload" token="Publication.Payload" displayname="AttributeDefinition'Payload'Publication" attributetype="Guid" isreadonly="False" isrequired="True" ismultivalue="False" iscanned="True" iscustom="False">
+					<OrderByAttribute href="/v1.six/meta.v1/Publication/Payload" tokenref="Publication.Payload"/>
+				</AttributeDefinition>
+			</AssetType>
+		</Response>
+		<Response path="rest-1.v1/Data/Publication?sel=Publication.Payload&amp;where=Publication.Payload='98771fb4-71b8-42ec-be8b-69414daa020e'">
+			<Asset href="/V1Production/rest-1.v1/Publication/12345" id="Publication:12345">
+				<Attribute name="Payload">98771fb4-71b8-42ec-be8b-69414daa020e</Attribute>
+			</Asset>
+		</Response>
+		<Response path="rest-1.v1/Data/Publication/12346/Payload?">
+     		<Asset href="/V1Production/rest-1.v1/Publication/12346" id="Publication:12346">
+       			<Attribute name="Payload"></Attribute>
+     		</Asset>
+   		</Response>
 	</Test>
 	<Test name="V1ConfigurationTester">
 		<Response path="config.v1/TrueOffOff">

--- a/testdata/TestData.xml
+++ b/testdata/TestData.xml
@@ -7,6 +7,8 @@
 				<OrderByAttribute href="/v1.six/meta.v1/Story/Name" tokenref="Story.Name" />
 			</AttributeDefinition>
 		</Response>
+
+
 		<Response path="meta.v1/Story">
 			<AssetType href="/v1.six/meta.v1/Story" version="6.5.55555.30353" name="Story" token="Story" displayname="AssetType'Story" abstract="False">
 				<Base nameref="PrimaryWorkitem" href="/v1.six/meta.v1/PrimaryWorkitem" />
@@ -59,6 +61,19 @@
 	</Test>
 
 	<Test name="AttributeDefinitionTester">
+		<Response path="meta.v1/Publication">
+			<AssetType href="/v1.six/meta.v1/Publication" version="6.5.55555.30353" name="Publication" token="Publication" displayname="AssetType'Publication" abstract="False">
+				<DefaultOrderBy href="/v1.six/meta.v1/Publication/Name" tokenref="Publication.Name" />
+				<AttributeDefinition name="Name" token="Publication.Name" displayname="AttributeDefinition'Name'Publication" attributetype="Text" isreadonly="False" isrequired="False" ismultivalue="False">
+					<OrderByAttribute href="/v1.six/meta.v1/Publication/Name" tokenref="Publication.Name" />
+				</AttributeDefinition>
+			</AssetType>
+		</Response>
+ 		<Response path="meta.v1/Publication/Payload">
+			<AttributeDefinition href="/v1.six/meta.v1/Publication/Payload" of="/v1.six/meta.v1/Publication" version="6.5.55555.30353" name="Payload" token="Publication.Payload" displayname="AttributeDefinition'Payload'Publication" attributetype="Guid" isreadonly="False" isrequired="True" ismultivalue="False">
+				<OrderByAttribute href="/v1.six/meta.v1/Publication/Payload" tokenref="Publication.Payload" />
+			</AttributeDefinition>
+		</Response>
 		<Response path="meta.v1/Story/Name">
 			<AttributeDefinition href="/v1.six/meta.v1/Story/Name" of="/v1.six/meta.v1/Story" version="6.5.55555.30353" name="Name" token="Story.Name" displayname="AttributeDefinition'Name'Story" attributetype="Text" isreadonly="False" isrequired="True" ismultivalue="False">
 				<Base href="/v1.six/meta.v1/BaseAsset/Name" tokenref="BaseAsset.Name" />


### PR DESCRIPTION
Resolves the Issue that when attempting to pre-load meta, the client throws an exception when it encounters the Publication/Payload attributetype, which is of type Guid.