### PR TITLE
Potential SDK fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.versionone</groupId>
 	<artifactId>VersionOne.SDK.Java.APIClient</artifactId>
-	<version>16.0.0</version>
+	<version>16.0.1</version>
 	<packaging>jar</packaging>
 
 	<name>VersionOne.SDK.Java.APIClient</name>

--- a/src/main/java/com/versionone/apiclient/V1Connector.java
+++ b/src/main/java/com/versionone/apiclient/V1Connector.java
@@ -343,8 +343,13 @@ public class V1Connector {
 	}
 
 	private HttpEntity setGETMethod(String path) {
-		
-		String url = V1Util.isNullOrEmpty(path) ? INSTANCE_URL + _endpoint : INSTANCE_URL + _endpoint + path;
+
+		String url = "";
+		if(_endpoint.equalsIgnoreCase(META_API_ENDPOINT)) {
+			url = V1Util.isNullOrEmpty(path) ? INSTANCE_URL + _endpoint : INSTANCE_URL + _endpoint + path + "?xml";
+		} else {
+			url = V1Util.isNullOrEmpty(path) ? INSTANCE_URL + _endpoint : INSTANCE_URL + _endpoint + path;
+		}
 
 		HttpGet request = new HttpGet(url);
 		setDefaultHeaderValue();

--- a/src/test/java/com/versionone/sdk/unit/tests/ServicesConstructorWhenPreLoadMetaIsFalse.java
+++ b/src/test/java/com/versionone/sdk/unit/tests/ServicesConstructorWhenPreLoadMetaIsFalse.java
@@ -26,11 +26,11 @@ public class ServicesConstructorWhenPreLoadMetaIsFalse {
     @Before
     public void setUp() throws Exception {
         WireMock.configureFor(8282);
-        wireMockRule.stubFor(get(urlEqualTo("/meta.v1/AssetType"))
+        wireMockRule.stubFor(get(urlEqualTo("/meta.v1/AssetType?xml"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody(MetaSamplePayload.AssetTypeType)));
-        wireMockRule.stubFor(get(urlEqualTo("/meta.v1/PrimaryRelation"))
+        wireMockRule.stubFor(get(urlEqualTo("/meta.v1/PrimaryRelation?xml"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody(MetaSamplePayload.PrimaryRelationType)));
@@ -61,7 +61,7 @@ public class ServicesConstructorWhenPreLoadMetaIsFalse {
 
     @Test
     public void itShouldAccessTheAssetTypeRoute() {
-        wireMockRule.verify(1, getRequestedFor(urlEqualTo("/meta.v1/AssetType")));
+        wireMockRule.verify(1, getRequestedFor(urlEqualTo("/meta.v1/AssetType?xml")));
     }
 
     @Test
@@ -71,6 +71,6 @@ public class ServicesConstructorWhenPreLoadMetaIsFalse {
 
     @Test
     public void itShouldAccessThePrimaryRelationRoute() {
-        wireMockRule.verify(1, getRequestedFor(urlEqualTo("/meta.v1/PrimaryRelation")));
+        wireMockRule.verify(1, getRequestedFor(urlEqualTo("/meta.v1/PrimaryRelation?xml")));
     }
 }


### PR DESCRIPTION
It appears that the default return format for a call to the "meta.v1/" endpoint has changed to JSON. It was previously XML. Adding this change will force calls to the "meta.v1/" endpoint to return XML thus allowing the XML parser to deserialize the objects properly.