### PR TITLE
Align IllegalArgumentException messages with legacy NullArgumentExcep…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.versionone</groupId>
 	<artifactId>VersionOne.SDK.Java.APIClient</artifactId>
-	<version>21.2.1</version>
+	<version>21.3.0</version>
 	<packaging>jar</packaging>
 
 	<name>VersionOne.SDK.Java.APIClient</name>

--- a/src/main/java/com/versionone/apiclient/AttributeDefinition.java
+++ b/src/main/java/com/versionone/apiclient/AttributeDefinition.java
@@ -118,7 +118,7 @@ class AttributeDefinition implements IAttributeDefinition {
                 return value;
             case Guid:
                 if (value == null || StringUtils.isEmpty(value.toString()))
-					throw new IllegalArgumentException("value");
+					throw new IllegalArgumentException("value must not be null.");
                 return UUID.fromString(new DB.Str(value).getValue());    
 			default:
 				throw new MetaException("Unsupported AttributeType ", getAttributeType().toString());

--- a/src/main/java/com/versionone/apiclient/Services.java
+++ b/src/main/java/com/versionone/apiclient/Services.java
@@ -88,7 +88,7 @@ public class Services implements IServices {
 
 	public Services(V1Connector v1Connector) {
 		if (v1Connector == null)
-			throw new IllegalArgumentException("v1Connector");
+			throw new IllegalArgumentException("v1Connector must not be null.");
 
 		_v1Connector = v1Connector;
 		_meta = new MetaModel(_v1Connector);
@@ -96,9 +96,9 @@ public class Services implements IServices {
 
 	public Services(V1Connector connector, IMetaModel metaModel) {
 		if (connector == null)
-			throw new IllegalArgumentException("connector");
+			throw new IllegalArgumentException("connector must not be null.");
 		if (metaModel == null)
-			throw new IllegalArgumentException("metaModel");
+			throw new IllegalArgumentException("metaModel must not be null.");
 
 		_v1Connector = connector;
 		_meta = metaModel;
@@ -106,7 +106,7 @@ public class Services implements IServices {
 
 	public Services(V1Connector connector, boolean preLoadMeta) {
 		if (connector == null)
-			throw new IllegalArgumentException("connector");
+			throw new IllegalArgumentException("connector must not be null.");
 
 		_v1Connector = connector;
 		_meta = new MetaModel(connector, preLoadMeta);
@@ -575,7 +575,7 @@ public class Services implements IServices {
 		if (null != attribute) {
 			return getStringData("?" + attribute.getDisplayName());
 		} else {
-			throw new IllegalArgumentException("IAttributeDefinition");
+			throw new IllegalArgumentException("attribute must not be null.");
 		}
 	}
 
@@ -650,7 +650,7 @@ public class Services implements IServices {
 	@Override
 	public Oid saveAttachment(String filePath, Asset asset, String attachmentName) throws V1Exception, IOException {
 		if (StringUtils.isEmpty(filePath))
-			 throw new IllegalArgumentException("filePath");
+			 throw new IllegalArgumentException("filePath must not be null.");
 
 		File file = new File(filePath);
         if (!file.exists())
@@ -711,7 +711,7 @@ public class Services implements IServices {
 	@Override
 	public Oid saveEmbeddedImage(String filePath, Asset asset) throws V1Exception, IOException {
 		if (StringUtils.isEmpty(filePath))
-			throw new IllegalArgumentException("Null value " + filePath);
+			throw new IllegalArgumentException("filePath must not be null.");
 
 		File file = new File(filePath);
         if (!file.exists())

--- a/src/main/java/com/versionone/apiclient/V1Configuration.java
+++ b/src/main/java/com/versionone/apiclient/V1Configuration.java
@@ -37,13 +37,13 @@ public class V1Configuration implements IV1Configuration {
      */
     public V1Configuration(IAPIConnector connector) {
     	if (connector == null)
-            throw new IllegalArgumentException("connector");
+            throw new IllegalArgumentException("connector must not be null.");
     	this._connector = connector;
     }
 
     public V1Configuration(V1Connector connector) {
     	if (connector == null)
-            throw new IllegalArgumentException("_v1connector");
+            throw new IllegalArgumentException("connector must not be null.");
 
         this._v1connector = connector;
     }

--- a/src/test/java/com/versionone/sdk/unit/tests/ServicesTests.java
+++ b/src/test/java/com/versionone/sdk/unit/tests/ServicesTests.java
@@ -199,7 +199,7 @@ public class ServicesTests extends ServicesTesterBase {
 			subject.retrieve(query);
 		} catch (IllegalArgumentException ex) {
 			Assert.assertEquals(
-					"value",
+					"value must not be null.",
 					ex.getMessage());
 			return;
 		}


### PR DESCRIPTION
After migrating from commons-lang NullArgumentException to IllegalArgumentException, update validation messages to preserve legacy message style and readability.